### PR TITLE
Add cell hit label as a configurable parameter

### DIFF
--- a/fcl/noe.fcl
+++ b/fcl/noe.fcl
@@ -4,6 +4,11 @@ standard_noe:
 {
   module_type:      noe
 
+  # Cell Hits are required. This string must match the module label
+  # of a rb::CellHit product in the event record, or the event display
+  # will not start.
+  cellhit_label: "calhit"
+
   # By default, display BreakPointFitter tracks. The user can change
   # this to another reconstruction, or can disable track display it by
   # specifying "" (the empty string).

--- a/noe_module.cc
+++ b/noe_module.cc
@@ -271,8 +271,8 @@ void noe::produce(art::Event& evt)
   art::Handle< vector<rb::CellHit> > cellhits;
 
   if(!evt.getByLabel(fCellHitLabel, cellhits)){
-    fprintf(stderr, "NOE needs CellHits with label \"%s\", but "
-            "event %d doesn't have those.\n", fCellHitLabel.c_str(), evt.event());
+    fprintf(stderr, "NOE needs CellHits with label \"%s\" as configured in your "
+      "FCL, but event %d doesn't have those.\n", fCellHitLabel.c_str(), evt.event());
     return;
   }
 

--- a/noe_module.cc
+++ b/noe_module.cc
@@ -37,12 +37,14 @@ class noe : public art::EDProducer {
 
   // The art labels for tracks and vertices that we are going to display, or
   // the empty string to display none.
+  std::string fCellHitLabel;
   std::string fTrackLabel;
   std::string fVertexLabel;
 };
 
 noe::noe(fhicl::ParameterSet const & pset)
 {
+  fCellHitLabel = pset.get< std::string >("cellhit_label");
   fTrackLabel = pset.get< std::string >("track_label");
   fVertexLabel= pset.get< std::string >("vertex_label");
 }
@@ -268,9 +270,9 @@ void noe::produce(art::Event& evt)
 
   art::Handle< vector<rb::CellHit> > cellhits;
 
-  if(!evt.getByLabel("calhit", cellhits)){
-    fprintf(stderr, "NOE needs CellHits with label \"calhit\", but "
-            "event %d doesn't have those.\n", evt.event());
+  if(!evt.getByLabel(fCellHitLabel, cellhits)){
+    fprintf(stderr, "NOE needs CellHits with label \"%s\", but "
+            "event %d doesn't have those.\n", fCellHitLabel.c_str(), evt.event());
     return;
   }
 


### PR DESCRIPTION
This PR includes a single commit to allow one to specify the cell hit label via FCL module configuration instead of in the module code itself.

If an empty or invalid label is given, the module will still throw an error message at the user and move on to the next event.

Tested with `development:debug` build of NOvASoft on 29 November 2018.